### PR TITLE
[Reporting Form] Create types for submissions & responses

### DIFF
--- a/model/form_submission.ts
+++ b/model/form_submission.ts
@@ -53,3 +53,9 @@ export enum SharkType {
   /** Any other shark species not listed above. */
   other = "other",
 }
+
+/** An form submission that has not yet been validated or persisted. */
+export type FormResponse = Omit<
+  FormSubmission,
+  "id" | "user_id" | "created_at"
+>;

--- a/model/form_submission.ts
+++ b/model/form_submission.ts
@@ -1,0 +1,55 @@
+import { v4 as uuidv4 } from "uuid";
+
+export type UUID = typeof uuidv4;
+
+/** A persisted record of a form submission fetched from the DB. */
+export interface FormSubmission {
+  id: UUID;
+  /** The time the record was added to the DB. Postgres timestamptz. */
+  created_at: string;
+  /**
+   * Supabase user ID of the author, if they were logged in while submitting
+   * the form.
+   */
+  user_id?: UUID | null;
+
+  /** The type of shark that was sighted. */
+  shark_type: SharkType;
+  /**
+   * The time the shark was sighted, according to the author.
+   * Postgres timestamptz.
+   */
+  sighting_time: string;
+  /** Whether the author saw the shark get caught by a fisherman. */
+  was_caught: boolean;
+  /**
+   * Whether the author saw the shark get release after being cuaght by a
+   * fisherman.
+   */
+  was_released: boolean;
+
+  /**
+   * Optional common location name for the place where the shark was
+   * sighted, e.g. "Pier 39"
+   */
+  location_name?: string | null;
+  /** String representation of the latitude where the shark was sighted. */
+  location_lat?: string | null;
+  /** String representation of the longitude where the shark was sighted. */
+  location_long?: string | null;
+
+  /** Email submitted by the author of the submission. */
+  email?: string | null;
+  /** The name of the author of the submission, as submitted. */
+  author_name?: string | null;
+  /** Whether the author has opted into receving Shark Stewards' newsletter. */
+  should_subscribe: boolean;
+  /** Whether the author has opted into receving updates about the app. */
+  confirm_get_app_updates: boolean;
+}
+
+/** Shark species that can be specified in the reporting form. */
+export enum SharkType {
+  /** Any other shark species not listed above. */
+  other = "other",
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
         "framer-motion": "^4.1.17",
         "next": "11.1.0",
         "react": "17.0.2",
-        "react-dom": "17.0.2"
+        "react-dom": "17.0.2",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/next": "^9.0.0",
         "@types/react": "^17.0.19",
+        "@types/uuid": "^8.3.1",
         "@typescript-eslint/eslint-plugin": "^4.29.2",
         "eslint": "7.32.0",
         "eslint-config-next": "11.1.0",
@@ -1953,6 +1955,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "dev": true
     },
     "node_modules/@types/warning": {
       "version": "3.0.0",
@@ -7391,6 +7399,14 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -9057,6 +9073,12 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
       "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
+    },
+    "@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
+      "dev": true
     },
     "@types/warning": {
       "version": "3.0.0",
@@ -13238,6 +13260,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "framer-motion": "^4.1.17",
     "next": "11.1.0",
     "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react-dom": "17.0.2",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/next": "^9.0.0",
     "@types/react": "^17.0.19",
+    "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.29.2",
     "eslint": "7.32.0",
     "eslint-config-next": "11.1.0",


### PR DESCRIPTION
Adds types that we can share across the frontend and backend for fully persisted `FormSubmission`s and unvalidated `FormResponse`s:

- `FormSubmission`s can be used to render historical data for logged-in users
- `FormResponse`s  can be used when submitting a form to the API