### PR TITLE
[Reporting Form] Refactor + add backend validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "lint-fix": "next lint --fix"
+    "lint-fix": "next lint --fix",
+    "compile": "tsc"
   },
   "dependencies": {
     "@chakra-ui/icons": "^1.0.15",

--- a/pages/api/postReport.ts
+++ b/pages/api/postReport.ts
@@ -1,10 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { ValidationError } from "yup";
-import {
-  FormSubmission,
-  reportFormSchema,
-  UUID,
-} from "../../model/form_submission";
+import { FormSubmission, reportFormSchema } from "../../model/form_submission";
 import { supabase } from "../../utils/supabaseClient";
 
 export type PostReportResponse =

--- a/pages/api/postReport.ts
+++ b/pages/api/postReport.ts
@@ -1,62 +1,62 @@
-import { PostgrestError, User } from "@supabase/supabase-js";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { ValidationError } from "yup";
+import {
+  FormSubmission,
+  reportFormSchema,
+  UUID,
+} from "../../model/form_submission";
 import { supabase } from "../../utils/supabaseClient";
 
-export interface postReportResponse {
-  data?: Object;
-  error?: PostgrestError;
-}
+export type PostReportResponse =
+  | {
+      success: true;
+      submission: FormSubmission;
+    }
+  | {
+      success: false;
+      error: string;
+    };
 
 export default async function postReport(
   req: NextApiRequest,
-  res: NextApiResponse
+  res: NextApiResponse<PostReportResponse>
 ) {
-  console.log(req.body);
-  const {
-    locationName,
-    sightingTime,
-    sharkType,
-    description,
-    email,
-    locationLong,
-    locationLat,
-    userId,
-    shouldSubscribe,
-    authorName,
-    confirmedGetAppUpdates,
-    wasCaught,
-    wasReleased,
-  } = req.body;
-
-  if (locationName == null || locationName === "") {
-    res.status(400).json({ error: "You must provide a location." });
-    return;
+  const authToken = req.headers.authorization;
+  let user_id: string | undefined;
+  if (authToken != null) {
+    supabase.auth.setAuth(authToken);
+    const { data, error } = await supabase.auth.api.getUser(authToken);
+    if (error) {
+      res.status(401).json({
+        success: false,
+        error: error.message,
+      });
+      return;
+    }
+    user_id = data.id;
   }
 
-  const { data, error } = await supabase.from("form_submissions").insert([
-    {
-      user_id: userId,
-      location_name: locationName,
-      sighting_time: sightingTime,
-      shark_type: sharkType,
-      description: description,
-      location_lat: locationLat,
-      location_long: locationLong,
-      email: email,
-      should_subscribe: shouldSubscribe ? shouldSubscribe : false,
-      author_name: authorName,
-      confirmed_get_app_updates: confirmedGetAppUpdates
-        ? confirmedGetAppUpdates
-        : false,
-      was_caught: wasCaught ? wasCaught : false,
-      was_released: wasCaught && wasReleased ? wasReleased : null,
-    },
-  ]);
-  if (error) {
-    console.log(error);
-    res.status(400).json({ error: error } as postReportResponse);
-    return;
-  } else {
-    res.status(200).json(data as postReportResponse);
+  try {
+    const validEntries = await reportFormSchema.validate({
+      ...req.body,
+      user_id,
+    });
+    const { data, error } = await supabase
+      .from("form_submissions")
+      .insert(validEntries);
+    if (error) {
+      console.error(error);
+      res.status(400).json({ success: false, error: error.message });
+      return;
+    } else {
+      res.status(201).json({ success: true, submission: data[0] });
+    }
+  } catch (e) {
+    let status = e instanceof ValidationError ? 422 : 400;
+    let error = "Something went wrong. Please try again.";
+    if (e.message != null) {
+      error = e.message;
+    }
+    res.status(status).json({ success: false, error });
   }
 }

--- a/pages/report.tsx
+++ b/pages/report.tsx
@@ -432,7 +432,7 @@ function SharkWasReleasedCheckboxField(fieldProps: FieldConfig) {
     >
       <Checkbox {...field} size="lg" id={fieldName}>
         <FormLabel paddingTop={2} htmlFor={fieldName}>
-          Was the shark was safely released after being caught?
+          Was the shark safely released after being caught?
         </FormLabel>
       </Checkbox>
     </FormControl>

--- a/pages/report.tsx
+++ b/pages/report.tsx
@@ -1,9 +1,8 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { PropsWithChildren, useState } from "react";
 import {
   Alert,
   AlertIcon,
   Box,
-  Flex,
   Button,
   Input,
   Checkbox,
@@ -14,7 +13,10 @@ import {
   FormLabel,
   FormErrorMessage,
   FormHelperText,
-  FormControlProps,
+  Container,
+  useToast,
+  Heading,
+  Divider,
 } from "@chakra-ui/react";
 import { useRouter } from "next/router";
 import {
@@ -25,11 +27,17 @@ import {
   useFormikContext,
   useField,
   FieldConfig,
+  FieldProps,
 } from "formik";
-import * as Yup from "yup";
 import { useSessionUser } from "../session/useSessionUser";
 import { DateTime } from "luxon";
 import { DatePicker } from "../components/DatePicker";
+import {
+  reportFormSchema,
+  SharkType,
+  UnsubmittedFormResponse,
+} from "../model/form_submission";
+import { PostReportResponse } from "./api/postReport";
 
 /** Which part of the form is currently being rendered. */
 enum FormStep {
@@ -52,39 +60,32 @@ enum FormStep {
   AuthorInfo,
 }
 
+function useInitialFormValues(): UnsubmittedFormResponse {
+  const email = useSessionUser().session?.user.email;
+  return {
+    location_name: undefined,
+    sighting_time: DateTime.now().toISO(),
+    shark_type: SharkType.other,
+    was_caught: false,
+    was_released: false,
+    author_name: undefined,
+    email,
+    should_subscribe: false,
+    confirmed_get_app_updates: false,
+  };
+}
+
 export default function Report() {
+  const toast = useToast();
   const [currentStep, setCurrentStep] = useState(FormStep.SightingDetails);
-  const [errorMessage, setErrorMessage] = useState<string>();
   const router = useRouter();
   const { session } = useSessionUser();
-
-  const reportFormSchema = useMemo(
-    () =>
-      Yup.object().shape({
-        locationName: Yup.string().required(
-          "Please enter where you saw the shark."
-        ),
-        sightingTime: Yup.string()
-          .required("Please enter when you saw the shark.")
-          .default(() => DateTime.now().toISO()),
-        email: Yup.string()
-          .email("Invalid email")
-          .default(() => {
-            return session?.user.email;
-          }),
-        authorName: Yup.string(),
-        sharkType: Yup.string().required(
-          `Select the type of shark you saw or "I don't know."`
-        ),
-      }),
-    [session?.user]
-  );
+  const defaultFormFormValues = useInitialFormValues();
 
   async function submitForm<FormValuesType>(
     values: FormValuesType,
     actions: FormikHelpers<FormValuesType>
   ) {
-    console.log(values);
     try {
       const data = await fetch("/api/postReport", {
         method: "POST",
@@ -94,274 +95,182 @@ export default function Report() {
         },
         body: JSON.stringify(values),
       });
-      console.log(data);
-      if (data.status === 400) {
-        setErrorMessage(`Please check the form for errors and try again.`);
-      } else if (data.status === 401) {
-        setErrorMessage(`Server Error: ${JSON.stringify(data.status)}`);
-      } else {
+      const response: PostReportResponse = await data.json();
+      // `=== true` narrows the type in the else-case
+      if (response.success === true) {
+        toast({
+          title: "Report submitted successfully! Finishing up...",
+          status: "success",
+        });
         router.push("/confirmReport");
+        return;
+      }
+
+      if (data.status === 422) {
+        toast({
+          title: "Check the form for errors",
+          description: response.error,
+          status: "error",
+          isClosable: true,
+        });
+      } else if (data.status === 401) {
+        toast({
+          title: "Your session has expired",
+          description: "Please log in again to continue.",
+          status: "error",
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: "Something went wrong",
+          description: "Please check your connection and try again.",
+          status: "error",
+          isClosable: true,
+        });
       }
     } catch (error: unknown) {
-      let message: string;
-      if (error instanceof Error) {
-        message = `Something went wrong: ${error.message}`;
-      } else {
-        message = `Something went wrong. Please try again.`;
-      }
-      setErrorMessage(message);
+      toast({
+        title: "Something went wrong",
+        description: "Please check your connection and try again.",
+        status: "error",
+        isClosable: true,
+      });
     } finally {
       actions.setSubmitting(false);
     }
   }
 
   return (
-    <Flex
-      align="start"
-      justify="center"
-      flexDirection="column"
-      width="100%"
-      height="100%"
-    >
-      <VStack align="center" margin="auto" width="lg" height="100%">
-        <Box m={2} p={3}>
-          {errorMessage != null && (
-            <Alert status="error">
-              <AlertIcon />
-              {errorMessage}
-            </Alert>
-          )}
-          <Formik
-            initialValues={{
-              locationName: undefined,
-              email: undefined,
-              sightingTime: DateTime.now().toISO(),
-              authorName: undefined,
-              sharkType: undefined,
-            }}
-            validationSchema={reportFormSchema}
-            onSubmit={(values, actions) => {
-              actions.setSubmitting(true);
-              submitForm(values, actions);
-            }}
-          >
-            {(props) => (
-              <Form>
-                <Field name="locationName">
-                  {({ field, form }) => (
-                    <FormControl
-                      isRequired
-                      isInvalid={
-                        form.errors.locationName && form.touched.locationName
-                      }
-                    >
-                      <FormLabel mb={2} mt={2} htmlFor="locationName">
-                        Where did you see the shark(s)?
-                      </FormLabel>
-                      <Input
-                        {...field}
-                        id="locationName"
-                        placeholder="San Francisco"
-                      />
-                      {form.errors.locationName && form.touched.locationName ? (
-                        <FormErrorMessage>
-                          {form.errors.locationName}
-                        </FormErrorMessage>
-                      ) : null}
-                    </FormControl>
-                  )}
-                </Field>
+    <Container>
+      <VStack marginBottom="8">
+        <Alert status="info" colorScheme="gray">
+          <AlertIcon />
+          Fill out the information below to report what you have seen. This data
+          is used for ocean conservation research purposes only.
+        </Alert>
+        <Formik
+          initialValues={defaultFormFormValues}
+          validationSchema={reportFormSchema}
+          onSubmit={(values, actions) => {
+            actions.setSubmitting(true);
+            submitForm(values, actions);
+          }}
+        >
+          {(props) => (
+            <Form>
+              {currentStep == FormStep.SightingDetails && (
+                <>
+                  <StringFormField
+                    fieldName="location_name"
+                    isRequired
+                    label="Where did you see the shark(s)?"
+                    placeholder={`Pier 39`}
+                    hint={
+                      <>
+                        Search for a location by typing above or select{" "}
+                        <strong>My Location.</strong>
+                      </>
+                    }
+                  >
+                    <Button variant="ghost" size="sm" padding="5">
+                      📍 My Location
+                    </Button>
+                  </StringFormField>
 
-                <SightingDateField name="sightingTime" />
+                  <SightingDateField name="sighting_time" />
 
-                <Field name="sharkType">
-                  {({ field, form }) => (
-                    <FormControl
-                      isRequired
-                      isInvalid={
-                        form.errors.sharkType && form.touched.sharkType
-                      }
-                    >
-                      <FormLabel mb={2} mt={2} htmlFor="sharkType">
-                        Do you know what kind of shark it was?
-                      </FormLabel>
-                      {/* TODO replace this with shark picker component, default to "I don't know" */}
-                      <Input
-                        {...field}
-                        id="sharkType"
-                        placeholder="Type of Shark"
-                      />
-                      {form.errors.sharkType && form.touched.sharkType ? (
-                        <FormErrorMessage>
-                          {form.errors.sharkType}
-                        </FormErrorMessage>
-                      ) : null}
-                    </FormControl>
-                  )}
-                </Field>
+                  <StringFormField
+                    fieldName="shark_type"
+                    isRequired
+                    label="What kind of shark did you see?"
+                    placeholder="Type of Shark"
+                  />
 
-                <Field name="wasCaught">
-                  {({ field, form }) => (
-                    <FormControl isRequired marginTop={2}>
-                      <HStack spacing="24px">
-                        <Checkbox {...field} name="wasCaught" size="lg">
-                          <FormLabel marginTop={2}>
-                            I saw the shark get caught by a fisherman.
-                          </FormLabel>
-                        </Checkbox>
-                      </HStack>
-                      <FormHelperText>
-                        Check this box if you saw the shark out of the water
-                        after being removed by a human (even if it was later
-                        returned safely).
-                      </FormHelperText>
-                    </FormControl>
-                  )}
-                </Field>
-                <SharkWasReleasedCheckboxField
-                  name="wasReleased"
-                  marginBottom={2}
-                />
-
-                <Field name="description">
-                  {({ field, form }) => (
-                    <FormControl
-                      isInvalid={
-                        form.errors.description && form.touched.description
-                      }
-                    >
-                      <FormLabel mb={2} mt={2} htmlFor="description">
-                        Is there other information you can provide?
-                      </FormLabel>
-                      <Textarea
-                        {...field}
-                        id="description"
-                        placeholder="Details..."
-                      />
-                      <FormHelperText>
-                        The more accurate our data the more of an impact we can
-                        make{" "}
-                      </FormHelperText>
-                      {form.errors.description && form.touched.description ? (
-                        <FormErrorMessage>
-                          {form.errors.description}
-                        </FormErrorMessage>
-                      ) : null}
-                    </FormControl>
-                  )}
-                </Field>
-
-                {currentStep === FormStep.AuthorInfo && (
-                  <Box>
-                    <Field name="authorName">
-                      {({ field, form }) => (
-                        <FormControl>
-                          <FormLabel mb={2} htmlFor="authorName">
-                            Author Name
-                          </FormLabel>
-                          <Input
-                            {...field}
-                            id="authorName"
-                            placeholder="Your Name"
-                          />
-                          {form.errors.authorName && form.touched.authorName ? (
-                            <FormErrorMessage>
-                              {form.errors.authorName}
-                            </FormErrorMessage>
-                          ) : null}
-                        </FormControl>
-                      )}
-                    </Field>
-                    <Field name="email">
-                      {({ field, form }) => (
-                        <FormControl>
-                          <FormLabel mb={2} mt={4} htmlFor="email">
-                            Email
-                          </FormLabel>
-                          <Input
-                            {...field}
-                            id="email"
-                            placeholder="Email"
-                            type="email"
-                          />
-                          {form.errors.email && form.touched.email ? (
-                            <FormErrorMessage>
-                              {form.errors.email}
-                            </FormErrorMessage>
-                          ) : null}
-                        </FormControl>
-                      )}
-                    </Field>
-                    <HStack>
-                      <Field name="shouldSubscribe">
-                        {({ field }) => (
-                          <FormControl>
-                            <Flex flexDirection="row" justifyContent="left">
-                              <Checkbox m={1} {...field} id="shouldSubscribe" />
-                              <FormLabel m={2}>
-                                Hear about Shark Stewards updates
-                              </FormLabel>
-                            </Flex>
-                          </FormControl>
-                        )}
-                      </Field>
-
-                      <Field name="confirmedGetAppUpdates">
-                        {({ field }) => (
-                          <FormControl>
-                            <Flex flexDirection="row" justifyContent="left">
-                              <Checkbox
-                                m={1}
-                                {...field}
-                                id="confirmedGetAppUpdates"
-                              />
-                              <FormLabel m={2}>
-                                Subscribe to App Updates
-                              </FormLabel>
-                            </Flex>
-                          </FormControl>
-                        )}
-                      </Field>
-                    </HStack>
+                  <Box marginTop="8" marginBottom="8">
+                    <CheckboxFormField
+                      fieldName="was_caught"
+                      label="I saw the shark get caught by a fisherman."
+                      hint="Check this box if you saw the shark out of the water after being removed by a human (even if it was later returned safely)."
+                    />
+                    <SharkWasReleasedCheckboxField name="was_released" />
                   </Box>
-                )}
-                {session == null && currentStep === FormStep.SightingDetails ? (
-                  <Button
-                    mt={4}
-                    mb={2}
-                    width="100%"
-                    isDisabled={!props.dirty || !props.isValid}
-                    isLoading={props.isSubmitting || props.isValidating}
-                    onClick={(event) => {
-                      event.preventDefault();
-                      if (
-                        currentStep === FormStep.SightingDetails &&
-                        session == null
-                      ) {
-                        setCurrentStep(FormStep.AuthorInfo);
-                      }
-                    }}
-                  >
-                    Next
-                  </Button>
-                ) : (
-                  <Button
-                    mt={4}
-                    mb={2}
-                    width="100%"
-                    isDisabled={!props.touched || !props.isValid}
-                    isLoading={props.isSubmitting || props.isValidating}
-                    type={"submit"}
-                  >
-                    Submit
-                  </Button>
-                )}
-              </Form>
-            )}
-          </Formik>
-        </Box>
+
+                  <StringFormField
+                    fieldName="description"
+                    label="Is there other information you'd like provide?"
+                    placeholder="Details..."
+                    hint="The more accurate our data, the more of an impact you can make!"
+                    inputType="long_answer"
+                  />
+                </>
+              )}
+
+              {currentStep === FormStep.AuthorInfo && (
+                <Box marginTop="4" marginBottom="4">
+                  <Heading size="sm">
+                    Can we contact you about your report or other shark
+                    preservation efforts? Your information will never be given
+                    to a third party.
+                  </Heading>
+                  <Divider marginTop="2" marginBottom="3" />
+                  <StringFormField
+                    fieldName="author_name"
+                    label="Your Name (optional)"
+                    placeholder="Shark Friend"
+                  />
+                  <StringFormField
+                    fieldName="email"
+                    label="Your Email Address (optional)"
+                    placeholder="shark.helper@example.com"
+                    inputType="email"
+                  />
+                  <CheckboxFormField
+                    fieldName="should_subscribe"
+                    label="Subscribe to Shark Stewards updates"
+                  />
+
+                  <CheckboxFormField
+                    fieldName="confirmed_get_app_updates"
+                    label="I'd like to be notified when we improve this site"
+                  />
+                </Box>
+              )}
+              {session == null && currentStep === FormStep.SightingDetails ? (
+                <Button
+                  mt={4}
+                  mb={2}
+                  width="100%"
+                  isDisabled={!props.touched || !props.isValid}
+                  isLoading={props.isSubmitting || props.isValidating}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (
+                      currentStep === FormStep.SightingDetails &&
+                      session == null
+                    ) {
+                      setCurrentStep(FormStep.AuthorInfo);
+                    }
+                  }}
+                >
+                  Next
+                </Button>
+              ) : (
+                <Button
+                  mt={4}
+                  mb={2}
+                  width="100%"
+                  isDisabled={!props.touched || !props.isValid}
+                  isLoading={props.isSubmitting || props.isValidating}
+                  type={"submit"}
+                >
+                  Submit
+                </Button>
+              )}
+            </Form>
+          )}
+        </Formik>
       </VStack>
-    </Flex>
+    </Container>
   );
 }
 
@@ -374,6 +283,7 @@ function SightingDateField(props: FieldConfig) {
         When?
       </FormLabel>
       <DatePicker
+        placeholderText="Pick a time..."
         id="sightingTime"
         showTimeSelect
         dateFormat={"MMMM d, yyyy h:mm aa"}
@@ -397,24 +307,120 @@ function SightingDateField(props: FieldConfig) {
   );
 }
 
+interface StringFormFieldProps {
+  fieldName: keyof UnsubmittedFormResponse;
+  label: string;
+  placeholder: string;
+  isRequired?: boolean;
+  inputType?: "short_answer" | "email" | "long_answer";
+  /** Additional helper text displayed below the text input. */
+  hint?: React.ReactNode;
+}
+
+/**
+ * A Formik field for string-type inputs that renders using Chakra's form components.
+ * @see https://formik.org/docs/api/field#component
+ */
+function StringFormField({
+  fieldName,
+  label,
+  placeholder,
+  hint,
+  inputType = "short_answer",
+  isRequired = false,
+  children,
+}: PropsWithChildren<StringFormFieldProps>) {
+  const TextInputComponent = inputType === "long_answer" ? Textarea : Input;
+  return (
+    <FormControl isRequired={isRequired}>
+      <FormLabel marginTop={2} htmlFor={fieldName}>
+        {label}
+      </FormLabel>
+      <Field name={fieldName}>
+        {({ field, form }: FieldProps<string, UnsubmittedFormResponse>) => (
+          <>
+            <HStack>
+              <TextInputComponent
+                {...field}
+                id={fieldName}
+                placeholder={placeholder}
+                type={
+                  inputType !== "short_answer" && inputType !== "long_answer"
+                    ? inputType
+                    : undefined
+                }
+              />
+              {children}
+            </HStack>
+            {hint && <FormHelperText>{hint}</FormHelperText>}
+            {form.errors[fieldName] != null && form.touched[fieldName] ? (
+              <FormErrorMessage>{form.errors[fieldName]}</FormErrorMessage>
+            ) : null}
+          </>
+        )}
+      </Field>
+    </FormControl>
+  );
+}
+
+interface CheckboxFormFieldProps {
+  fieldName: keyof UnsubmittedFormResponse;
+  label: string;
+  isRequired?: boolean;
+  /** Additional helper text displayed below the text input. */
+  hint?: React.ReactNode;
+}
+
+/**
+ * A Formik field for boolean-type inputs that renders using Chakra's form components.
+ * @see https://formik.org/docs/api/field#component
+ */
+function CheckboxFormField({
+  fieldName,
+  label,
+  hint,
+  isRequired = false,
+}: CheckboxFormFieldProps) {
+  return (
+    <FormControl isRequired={isRequired}>
+      <Field name={fieldName}>
+        {({
+          field,
+          form,
+        }: FieldProps<string | number, UnsubmittedFormResponse>) => (
+          <>
+            <Checkbox {...field} id={fieldName} size="lg">
+              <FormLabel htmlFor={fieldName} paddingTop={2}>
+                {label}
+              </FormLabel>
+            </Checkbox>
+            {hint && <FormHelperText>{hint}</FormHelperText>}
+            {form.errors[fieldName] != null && form.touched[fieldName] ? (
+              <FormErrorMessage>{form.errors[fieldName]}</FormErrorMessage>
+            ) : null}
+          </>
+        )}
+      </Field>
+    </FormControl>
+  );
+}
+
 /**
  * @see https://formik.org/docs/examples/dependent-fields
  */
-function SharkWasReleasedCheckboxField({
-  marginBottom,
-  ...fieldProps
-}: FieldConfig & Pick<FormControlProps, "marginBottom">) {
+function SharkWasReleasedCheckboxField(fieldProps: FieldConfig) {
   const {
-    values: { wasCaught },
+    values: { was_caught: wasCaught },
     setFieldValue,
-  } = useFormikContext<{ wasCaught?: boolean }>();
+  } = useFormikContext<Pick<UnsubmittedFormResponse, "was_caught">>();
   const [field, meta] = useField(fieldProps);
+  const fieldName = fieldProps.name;
 
   React.useEffect(() => {
     if (!wasCaught) {
-      setFieldValue(fieldProps.name, undefined, false);
+      setFieldValue(fieldName, false, false);
     }
-  }, [wasCaught, setFieldValue, fieldProps.name]);
+  }, [wasCaught, setFieldValue, fieldName]);
 
   if (!wasCaught) {
     return null;
@@ -425,19 +431,12 @@ function SharkWasReleasedCheckboxField({
       isRequired
       isDisabled={!wasCaught}
       isInvalid={meta.error && meta.touched}
-      marginBottom={marginBottom}
     >
-      <Checkbox {...field} name="wasReleased" size="lg">
-        <FormLabel marginTop={2}>
-          The shark was safely released after being caught.
+      <Checkbox {...field} size="lg" id={fieldName}>
+        <FormLabel paddingTop={2} htmlFor={fieldName}>
+          Was the shark was safely released after being caught?
         </FormLabel>
       </Checkbox>
-      {wasCaught && (
-        <FormHelperText>
-          Check this box if you saw the fisherman who caught the shark(s) also
-          release them safely back into the ocean.
-        </FormHelperText>
-      )}
     </FormControl>
   );
 }

--- a/pages/report.tsx
+++ b/pages/report.tsx
@@ -63,12 +63,10 @@ enum FormStep {
 function useInitialFormValues(): UnsubmittedFormResponse {
   const email = useSessionUser().session?.user.email;
   return {
-    location_name: undefined,
     sighting_time: DateTime.now().toISO(),
     shark_type: SharkType.other,
     was_caught: false,
     was_released: false,
-    author_name: undefined,
     email,
     should_subscribe: false,
     confirmed_get_app_updates: false,
@@ -240,7 +238,7 @@ export default function Report() {
                   mt={4}
                   mb={2}
                   width="100%"
-                  isDisabled={!props.touched || !props.isValid}
+                  isDisabled={!props.dirty || !props.isValid}
                   isLoading={props.isSubmitting || props.isValidating}
                   onClick={(event) => {
                     event.preventDefault();
@@ -259,7 +257,7 @@ export default function Report() {
                   mt={4}
                   mb={2}
                   width="100%"
-                  isDisabled={!props.touched || !props.isValid}
+                  isDisabled={!props.dirty || !props.isValid}
                   isLoading={props.isSubmitting || props.isValidating}
                   type={"submit"}
                 >


### PR DESCRIPTION
Lots of refactoring of the form submission flow:

- Add some reusable components for string-type and boolean-type fields
- Display responses with a toast
- Fix layout issues in mobile width
- Update copy and add info message
- Add placeholder location button
- Make form really have two "steps"
- Attached user_id if logged in
- Share validation across frontend and backend