### PR TITLE
[🧹] Address lint warnings + add social links to footer

### DIFF
--- a/components/AppFooter.tsx
+++ b/components/AppFooter.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from "react";
 import {
   Box,
   Container,
+  Icon,
   Link,
   SimpleGrid,
   Stack,
@@ -10,6 +11,7 @@ import {
   chakra,
   useColorModeValue,
 } from "@chakra-ui/react";
+import { FaFacebook, FaInstagram, FaYoutube } from "react-icons/fa";
 
 // Based On: hauptrolle/chakra-templates
 // License: https://github.com/hauptrolle/chakra-templates/blob/main/LICENSE
@@ -103,15 +105,24 @@ export function AppFooter() {
             © 2021 <strong>Shark Stewards</strong>
           </Text>
           <Stack direction={"row"} spacing={6}>
-            {/* <SocialButton label={"Twitter"} href={"#"}>
-              <FaTwitter />
+            <SocialButton
+              label={"Facebook"}
+              href={"https://www.facebook.com/SharkStewards/"}
+            >
+              <Icon as={FaFacebook} />
             </SocialButton>
-            <SocialButton label={"YouTube"} href={"#"}>
-              <FaYoutube />
+            <SocialButton
+              label={"Instagram"}
+              href={"https://www.instagram.com/sharkstewards/"}
+            >
+              <Icon as={FaInstagram} />
             </SocialButton>
-            <SocialButton label={"Instagram"} href={"#"}>
-              <FaInstagram />
-            </SocialButton> */}
+            <SocialButton
+              label={"YouTube"}
+              href={"https://www.youtube.com/c/Sharksaver/"}
+            >
+              <Icon as={FaYoutube} />
+            </SocialButton>
           </Stack>
         </Container>
       </Box>

--- a/components/Authentication.tsx
+++ b/components/Authentication.tsx
@@ -28,7 +28,7 @@ export function Authentication({ children }: AuthenticationProps) {
       .then(() => {
         setSession(null);
       })
-      .catch((error) => {
+      .catch(() => {
         toast({
           status: "error",
           title: "Unable to sign out",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "17.0.2",
         "react-datepicker": "^4.2.1",
         "react-dom": "17.0.2",
+        "react-icons": "^4.2.0",
         "uuid": "^8.3.2",
         "yup": "^0.32.9"
       },
@@ -6534,6 +6535,14 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -12859,6 +12868,12 @@
         "use-callback-ref": "^1.2.1",
         "use-sidecar": "^1.0.1"
       }
+    },
+    "react-icons": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "17.0.2",
     "react-datepicker": "^4.2.1",
     "react-dom": "17.0.2",
+    "react-icons": "^4.2.0",
     "uuid": "^8.3.2",
     "yup": "^0.32.9"
   },


### PR DESCRIPTION
Gets rid of the lint warnings for unused variables by removing one unused var and actually using the `<SocialLinks>` component (in footer).

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/3240322/132954659-af0bcbdc-64df-4d47-9ad7-ff81226a6ac7.png">
