### PR TITLE
[🛠] Enable fix on save in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.formatOnPaste": true,


### PR DESCRIPTION
Will automatically fix the auto-fixable ESLint errors when you save a file (e.g. unused imports, organized imports).